### PR TITLE
Add extension of file to `main` of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "wheel-indicator",
   "description": "normalizes an inertial mousewheel",
-  "main": "lib/wheel-indicator",
+  "main": "lib/wheel-indicator.js",
   "authors": [
     "Anton Grischenko <f0rmateg@yandex.ru>"
   ],


### PR DESCRIPTION
I propose to add extension of file to entry point.
There is a problem with the plugin `bower-webpack-plugin`, it requires [file extension](https://github.com/lpiepiora/bower-webpack-plugin/blob/master/lib/bower-loader.js#L51)
