### PR TITLE
Preventing Chrome console errors by adding active event listener on s…

### DIFF
--- a/lib/wheel-indicator.js
+++ b/lib/wheel-indicator.js
@@ -203,7 +203,7 @@ var WheelIndicator = (function() {
 
     function addEvent(elem, type, handler){
         if(elem.addEventListener) {
-            elem.addEventListener(type, handler, false);
+            elem.addEventListener(type, handler, { passive: false });
         } else if (elem.attachEvent) {
             elem.attachEvent('on' + type, handler);
         }
@@ -211,7 +211,7 @@ var WheelIndicator = (function() {
 
     function removeEvent(elem, type, handler) {
         if (elem.removeEventListener) {
-            elem.removeEventListener(type, handler, false);
+            elem.removeEventListener(type, handler, { passive: false });
         } else if (elem.detachEvent) {
             elem.detachEvent('on'+ type, handler);
         }


### PR DESCRIPTION
Solves [#50](https://github.com/Promo/wheel-indicator/issues/50)

Tested on MacOS Chrome 76, Firefox 69, Safari 12.1.2.

Edit: [more info about issue](https://developers.google.com/web/updates/2019/02/scrolling-intervention)